### PR TITLE
Add MiniBoard skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # mobile_test_repo_1
+
+This repository now contains the **MiniBoard** example application. See
+[`mini-board/README.md`](mini-board/README.md) for details.

--- a/mini-board/README.md
+++ b/mini-board/README.md
@@ -1,0 +1,12 @@
+# MiniBoard
+
+This folder contains a minimalist implementation of the **MiniBoard** project.
+It provides a typed Express server with Prisma ORM and shared Zod schemas for
+the core models (Board, Group, Item).
+
+## Structure
+- `client/` – placeholder for the React application.
+- `server/` – Express server with Prisma setup.
+- `shared/` – shared TypeScript types and Zod schemas.
+
+The server exposes basic CRUD APIs for boards, groups, and items.

--- a/mini-board/client/README.md
+++ b/mini-board/client/README.md
@@ -1,0 +1,1 @@
+Placeholder for the React frontend.

--- a/mini-board/server/index.ts
+++ b/mini-board/server/index.ts
@@ -1,0 +1,64 @@
+import express from 'express';
+import { PrismaClient } from '@prisma/client';
+import { boardSchema, groupSchema, itemSchema } from '../shared/schemas';
+
+const prisma = new PrismaClient();
+const app = express();
+app.use(express.json());
+
+app.get('/boards', async (_req, res) => {
+  const boards = await prisma.board.findMany();
+  res.json(boards);
+});
+
+app.post('/boards', async (req, res) => {
+  const parsed = boardSchema.partial({ id: true, createdAt: true }).safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error });
+    return;
+  }
+  const board = await prisma.board.create({ data: { name: parsed.data.name } });
+  res.json(board);
+});
+
+app.delete('/boards/:id', async (req, res) => {
+  await prisma.board.delete({ where: { id: req.params.id } });
+  res.status(204).send();
+});
+
+// Groups routes
+app.get('/boards/:boardId/groups', async (req, res) => {
+  const groups = await prisma.group.findMany({ where: { boardId: req.params.boardId }, orderBy: { order: 'asc' } });
+  res.json(groups);
+});
+
+app.post('/boards/:boardId/groups', async (req, res) => {
+  const parsed = groupSchema.partial({ id: true }).safeParse({ ...req.body, boardId: req.params.boardId });
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error });
+    return;
+  }
+  const group = await prisma.group.create({ data: parsed.data });
+  res.json(group);
+});
+
+// Items routes
+app.get('/groups/:groupId/items', async (req, res) => {
+  const items = await prisma.item.findMany({ where: { groupId: req.params.groupId }, orderBy: { position: 'asc' } });
+  res.json(items);
+});
+
+app.post('/groups/:groupId/items', async (req, res) => {
+  const parsed = itemSchema.partial({ id: true, createdAt: true, updatedAt: true, statusChangedAt: true, boardId: true, groupId: true }).safeParse({ ...req.body, groupId: req.params.groupId, boardId: req.body.boardId });
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error });
+    return;
+  }
+  const item = await prisma.item.create({ data: parsed.data });
+  res.json(item);
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/mini-board/server/package.json
+++ b/mini-board/server/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mini-board-server",
+  "version": "0.1.0",
+  "main": "index.ts",
+  "type": "module",
+  "dependencies": {
+    "@prisma/client": "^5.0.0",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "prisma": "^5.0.0",
+    "typescript": "^5.0.0"
+  },
+  "scripts": {
+    "start": "ts-node index.ts"
+  }
+}

--- a/mini-board/server/prisma/schema.prisma
+++ b/mini-board/server/prisma/schema.prisma
@@ -1,0 +1,42 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+model Board {
+  id        String   @id @default(uuid())
+  name      String
+  groups    Group[]
+  createdAt DateTime @default(now())
+}
+
+model Group {
+  id      String @id @default(uuid())
+  name    String
+  order   Int
+  board   Board  @relation(fields: [boardId], references: [id])
+  boardId String
+  items   Item[]
+}
+
+model Item {
+  id             String   @id @default(uuid())
+  title          String
+  description    String?
+  statusLabel    String
+  statusColor    String
+  assignee       String?
+  notes          String?
+  position       Int
+  group          Group    @relation(fields: [groupId], references: [id])
+  groupId        String
+  board          Board    @relation(fields: [boardId], references: [id])
+  boardId        String
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+  statusChangedAt DateTime?
+}

--- a/mini-board/server/tsconfig.json
+++ b/mini-board/server/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/mini-board/shared/schemas.ts
+++ b/mini-board/shared/schemas.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+export const boardSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  createdAt: z.string().optional(),
+});
+
+export const groupSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  order: z.number().int(),
+  boardId: z.string().uuid(),
+});
+
+export const itemSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string(),
+  description: z.string().nullish(),
+  statusLabel: z.string(),
+  statusColor: z.string(),
+  assignee: z.string().nullish(),
+  notes: z.string().nullish(),
+  position: z.number().int(),
+  groupId: z.string().uuid(),
+  boardId: z.string().uuid(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+  statusChangedAt: z.string().nullish(),
+});
+
+export type Board = z.infer<typeof boardSchema>;
+export type Group = z.infer<typeof groupSchema>;
+export type Item = z.infer<typeof itemSchema>;

--- a/mini-board/shared/types.ts
+++ b/mini-board/shared/types.ts
@@ -1,0 +1,28 @@
+export interface Board {
+  id: string;
+  name: string;
+  createdAt: string; // ISO date
+}
+
+export interface Group {
+  id: string;
+  name: string;
+  order: number;
+  boardId: string;
+}
+
+export interface Item {
+  id: string;
+  title: string;
+  description?: string | null;
+  statusLabel: string;
+  statusColor: string;
+  assignee?: string | null;
+  notes?: string | null;
+  position: number;
+  groupId: string;
+  boardId: string;
+  createdAt: string; // ISO date
+  updatedAt: string; // ISO date
+  statusChangedAt?: string | null;
+}


### PR DESCRIPTION
## Summary
- initialize project structure for MiniBoard example
- add shared types and zod schemas
- implement a typed Express server with Prisma models
- document new folders in README

## Testing
- `node -v`